### PR TITLE
Added functionality and styling to the 'my playlist' page

### DIFF
--- a/src/components/ui/cardComponentList/cardComponentList.jsx
+++ b/src/components/ui/cardComponentList/cardComponentList.jsx
@@ -6,11 +6,9 @@ import { fetchPlaylists } from '../../../slices/playlistSlice'
 import styles from '../cardComponentList/cardComponentList.module.css'
 import Search from '../search/Search'
 
-function CardComponentList() {
+function CardComponentList(props) {
+    const { playlists, status, error } = props
     const dispatch = useDispatch()
-    const playlists = useSelector((state) => state.playlists.items)
-    const status = useSelector((state) => state.playlists.status)
-    const error = useSelector((state) => state.playlists.error)
     const [filteredPlaylists, setFilteredPlaylists] = useState([])
 
     useEffect(() => {

--- a/src/components/ui/main/Main.jsx
+++ b/src/components/ui/main/Main.jsx
@@ -1,14 +1,30 @@
 import styles from './main.module.css'
 import CardComponentList from '../cardComponentList/cardComponentList'
 import PlaylistNav from '../playlistNav/PlaylistNav'
+import { useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { fetchPlaylists } from '../../../slices/playlistSlice'
 
 function Main() {
+    const dispatch = useDispatch()
+    const playlists = useSelector((state) => state.playlists.items)
+    const status = useSelector((state) => state.playlists.status)
+    const error = useSelector((state) => state.playlists.error)
+
+    useEffect(() => {
+        dispatch(fetchPlaylists())
+    }, [dispatch])
+
     return (
         <main>
             <PlaylistNav />
             <section className={styles.main}>
                 <h1>Dashboard</h1>
-                <CardComponentList />
+                <CardComponentList
+                    playlists={playlists}
+                    status={status}
+                    error={error}
+                />
             </section>
         </main>
     )

--- a/src/slices/myPlaylistSlice.js
+++ b/src/slices/myPlaylistSlice.js
@@ -1,0 +1,43 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
+
+// API env
+const API_URL = `${import.meta.env.VITE_API_URL}/api/my-playlists`
+
+export const fetchMyPlaylists = createAsyncThunk(
+    'playlists/fetchMyPlaylists',
+    async (_, { rejectWithValue }) => {
+        try {
+            const response = await fetch(API_URL)
+            if (!response.ok) throw new Error('Failed to fetch my playlists')
+            return await response.json()
+        } catch (error) {
+            return rejectWithValue(error.message)
+        }
+    }
+)
+
+const myPlaylistSlice = createSlice({
+    name: 'myPlaylists',
+    initialState: {
+        items: [],
+        status: 'idle',
+        error: null,
+    },
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(fetchMyPlaylists.pending, (state) => {
+                state.status = 'loading'
+            })
+            .addCase(fetchMyPlaylists.fulfilled, (state, action) => {
+                state.status = 'succeeded'
+                state.items = action.payload
+            })
+            .addCase(fetchMyPlaylists.rejected, (state, action) => {
+                state.status = 'failed'
+                state.error = action.payload
+            })
+    },
+})
+
+export default myPlaylistSlice.reducer

--- a/src/store.js
+++ b/src/store.js
@@ -2,14 +2,16 @@ import { configureStore } from '@reduxjs/toolkit'
 import authReducer from './slices/authSlice'
 import playlistReducer from './slices/playlistSlice'
 import usersReducer from './slices/usersSlice'
-import singlePlaylistReducer from "./slices/singlePlaylistSlice";
+import singlePlaylistReducer from './slices/singlePlaylistSlice'
+import myPlaylistSliceReducer from './slices/myPlaylistSlice'
 
 const store = configureStore({
     reducer: {
         auth: authReducer,
         playlists: playlistReducer,
         users: usersReducer,
-        singlePlaylist: singlePlaylistReducer
+        singlePlaylist: singlePlaylistReducer,
+        myPlaylists: myPlaylistSliceReducer,
     },
 })
 

--- a/src/views/my-playlists/MyPlaylists.jsx
+++ b/src/views/my-playlists/MyPlaylists.jsx
@@ -1,14 +1,32 @@
 import styles from '../../components/ui/main/main.module.css'
 import Search from '../../components/ui/search/Search'
 import PlaylistNav from '../../components/ui/playlistNav/PlaylistNav'
+import CardComponentList from '../../components/ui/cardComponentList/cardComponentList'
+import { useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { fetchMyPlaylists } from '../../slices/myPlaylistSlice'
 
 function MyPlaylists() {
+    const dispatch = useDispatch()
+    const myPlaylists = useSelector((state) => state.myPlaylists.items)
+    const status = useSelector((state) => state.myPlaylists.status)
+    const error = useSelector((state) => state.myPlaylists.error)
+
+    useEffect(() => {
+        dispatch(fetchMyPlaylists())
+    }, [dispatch])
+
     return (
         <main>
             <PlaylistNav />
             <section className={styles.main}>
                 <h1>My playlists</h1>
                 <Search />
+                <CardComponentList
+                    playlists={myPlaylists}
+                    status={status}
+                    error={error}
+                />
             </section>
         </main>
     )

--- a/src/views/my-playlists/MyPlaylists.jsx
+++ b/src/views/my-playlists/MyPlaylists.jsx
@@ -21,7 +21,6 @@ function MyPlaylists() {
             <PlaylistNav />
             <section className={styles.main}>
                 <h1>My playlists</h1>
-                <Search />
                 <CardComponentList
                     playlists={myPlaylists}
                     status={status}


### PR DESCRIPTION
In this PR I covered the following:

**JSX**:
- added 'my playlists' view to display the currently logged in user playlists
- made the 'playlist list' component pass in extra props to account to account for the fact that it could render multiple versions of a playlist list
- solved merged conflicts that would cause the 'search playlist' component to duplicate