### PR TITLE
Added sytyling for 'edit-playlist' button and its corresponding page

### DIFF
--- a/src/components/ui/header/header.module.css
+++ b/src/components/ui/header/header.module.css
@@ -4,7 +4,6 @@
     font-weight: 700;
     padding-block: 2em;
     align-items: center;
-    margin-bottom: 2em;
 
     img {
         width: 3.5em;

--- a/src/components/ui/playlistNav/PlaylistNav.jsx
+++ b/src/components/ui/playlistNav/PlaylistNav.jsx
@@ -9,18 +9,27 @@ function PlaylistNav() {
     if (isLoggedIn) {
         links.push({ label: 'My Playlists', url: '/myplaylists/' })
         links.push({ label: 'Users', url: '/users/' })
-        links.push({ label: '+ New Playlist', url: '/playlist/add/' })
+        links.push({
+            label: '+ New Playlist',
+            url: '/playlist/add/',
+            class: 'button',
+        })
     }
 
     return (
         <div className={styles.playlistNav}>
-            <NavLink to="/">All Playlists</NavLink>
+            <NavLink
+                to="/"
+                className={({ isActive }) => (isActive ? styles.active : 'no')}
+            >
+                All Playlists
+            </NavLink>
 
             {links.map((link) => (
                 <NavLink
                     to={link.url}
                     className={({ isActive }) =>
-                        isActive ? 'active-link' : 'no'
+                        isActive ? styles.active : ''
                     }
                 >
                     {link.label}

--- a/src/components/ui/playlistNav/playlistnav.module.css
+++ b/src/components/ui/playlistNav/playlistnav.module.css
@@ -5,7 +5,7 @@
     margin-bottom: 1em;
     color: var(--clr-light);
 
-    a:not(:nth-of-type(4)) {
+    :where(a:not(:nth-of-type(4))) {
         color: var(--clr-light);
         position: relative;
         font-weight: 500;
@@ -44,7 +44,7 @@
         text-transform: uppercase;
     }
 
-    .active-link {
+    .active {
         color: var(--clr-accent);
 
         &::after {

--- a/src/components/ui/root/root.module.css
+++ b/src/components/ui/root/root.module.css
@@ -2,7 +2,7 @@
     width: calc(100% - 4rem);
     margin-inline: auto;
     min-height: 100vh;
+    gap: 2em;
     flex-direction: column;
     display: flex;
-    /* position: relative; */
 }

--- a/src/views/edit/Edit.jsx
+++ b/src/views/edit/Edit.jsx
@@ -1,8 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { useParams, useNavigate } from 'react-router-dom'
-import styles from '../../components/ui/main/main.module.css'
-import PlaylistNav from '../../components/ui/playlistNav/PlaylistNav'
 import formStyles from '../../components/ui/form/form.module.css'
 import { fetchPlaylistById } from '../../slices/singlePlaylistSlice'
 import { updatePlaylist } from '../../slices/myPlaylistSlice'
@@ -33,7 +31,7 @@ const Edit = () => {
             setFormData({
                 name: playlist.name || '',
                 description: playlist.description || '',
-                coverImage: playlist.coverImage || '',
+                coverImage: playlist.image_url || '',
                 songs: playlist.songs || [],
             })
         }
@@ -64,6 +62,7 @@ const Edit = () => {
                 <input
                     type="text"
                     name="name"
+                    value={formData.name}
                     onChange={handleChange}
                     required
                 />
@@ -71,7 +70,12 @@ const Edit = () => {
 
             <div className={formStyles.form__group}>
                 <label>Description</label>
-                <textarea name="description" onChange={handleChange} required />
+                <textarea
+                    name="description"
+                    value={formData.description}
+                    onChange={handleChange}
+                    required
+                />
             </div>
 
             <div className={formStyles.form__group}>

--- a/src/views/edit/Edit.jsx
+++ b/src/views/edit/Edit.jsx
@@ -1,72 +1,94 @@
-import { useEffect, useState } from "react";
-import { useSelector, useDispatch } from "react-redux";
-import { useParams, useNavigate } from "react-router-dom";
-import { fetchPlaylistById, updatePlaylist } from "../../slices/singlePlaylistSlice";
+import { useEffect, useState } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { useParams, useNavigate } from 'react-router-dom'
+import {
+    fetchPlaylistById,
+    updatePlaylist,
+} from '../../slices/singlePlaylistSlice'
+import styles from '../../components/ui/main/main.module.css'
+import PlaylistNav from '../../components/ui/playlistNav/PlaylistNav'
+import formStyles from '../../components/ui/form/form.module.css'
 
 const Edit = () => {
-    const { item: playlist, status, error } = useSelector((state) => state.singlePlaylist);
-    const { id } = useParams();
-    const dispatch = useDispatch();
-    const navigate = useNavigate();
+    const {
+        item: playlist,
+        status,
+        error,
+    } = useSelector((state) => state.singlePlaylist)
+    const { id } = useParams()
+    const dispatch = useDispatch()
+    const navigate = useNavigate()
 
     const [formData, setFormData] = useState({
-        name: "",
-        description: "",
-        coverImage: "",
+        name: '',
+        description: '',
+        coverImage: '',
         songs: [],
-    });
+    })
 
     useEffect(() => {
-        if (id) dispatch(fetchPlaylistById(id));
-    }, [dispatch, id]);
+        if (id) dispatch(fetchPlaylistById(id))
+    }, [dispatch, id])
 
     useEffect(() => {
         if (playlist) {
             setFormData({
-                name: playlist.name || "",
-                description: playlist.description || "",
-                coverImage: playlist.coverImage || "",
+                name: playlist.name || '',
+                description: playlist.description || '',
+                coverImage: playlist.coverImage || '',
                 songs: playlist.songs || [],
-            });
+            })
         }
-    }, [playlist]);
+    }, [playlist])
 
     const handleChange = (e) => {
-        setFormData({ ...formData, [e.target.name]: e.target.value });
-    };
+        setFormData({ ...formData, [e.target.name]: e.target.value })
+    }
 
     const handleSubmit = (e) => {
-        e.preventDefault();
+        e.preventDefault()
         dispatch(updatePlaylist({ playlistId: id, updatedData: formData }))
             .then(() => {
-                navigate(`/playlist/${id}`); 
+                navigate(`/playlist/${id}`)
             })
-            .catch((error) => console.error("Error updating playlist:", error));
-    };
+            .catch((error) => console.error('Error updating playlist:', error))
+    }
 
-    if (status === "loading") return <p>Loading...</p>;
-    if (status === "failed") return <p>Error: {error}</p>;
+    if (status === 'loading') return <p>Loading...</p>
+    if (status === 'failed') return <p>Error: {error}</p>
 
     return (
-        <div>
-            <h1>Edit Playlist</h1>
-            <form onSubmit={handleSubmit}>
-                <label>
-                    Name:
-                    <input type="text" name="name" value={formData.name} onChange={handleChange} required />
-                </label>
-                <label>
-                    Description:
-                    <textarea name="description" value={formData.description} onChange={handleChange} required />
-                </label>
-                <label>
-                    Cover Image URL:
-                    <input type="text" name="coverImage" value={formData.coverImage} onChange={handleChange} />
-                </label>
-                <button type="submit">Save Changes</button>
-            </form>
-        </div>
-    );
-};
+        <form className={formStyles.form} onSubmit={handleSubmit}>
+            <legend className={formStyles.form__legend}>Edit Playlist</legend>
 
-export default Edit;
+            <div className={formStyles.form__group}>
+                <label>Name</label>
+                <input
+                    type="text"
+                    name="name"
+                    onChange={handleChange}
+                    required
+                />
+            </div>
+
+            <div className={formStyles.form__group}>
+                <label>Description</label>
+                <textarea name="description" onChange={handleChange} required />
+            </div>
+
+            <div className={formStyles.form__group}>
+                <label>Cover Image URL</label>
+                <input
+                    type="text"
+                    name="coverImage"
+                    value={formData.coverImage}
+                    onChange={handleChange}
+                />
+            </div>
+
+            <button type="submit">Save Changes</button>
+        </form>
+    )
+}
+
+export default Edit

--- a/src/views/my-playlists/MyPlaylists.jsx
+++ b/src/views/my-playlists/MyPlaylists.jsx
@@ -1,5 +1,4 @@
 import styles from '../../components/ui/main/main.module.css'
-import Search from '../../components/ui/search/Search'
 import PlaylistNav from '../../components/ui/playlistNav/PlaylistNav'
 import CardComponentList from '../../components/ui/cardComponentList/cardComponentList'
 import { useEffect } from 'react'

--- a/src/views/playlist/Playlist.jsx
+++ b/src/views/playlist/Playlist.jsx
@@ -74,13 +74,16 @@ const Playlist = () => {
                             </div>
                         ))}
                     </section>
-                    <Link to={`/playlist/${id}/edit/`}>
-                        <button>Edit Playlist</button>
+
+                    <Link
+                        className={playlistStyles.playlist__edit}
+                        to={`/playlist/${id}/edit/`}
+                    >
+                        Edit Playlist
                     </Link>
                 </div>
             </section>
         </main>
-
     )
 }
 

--- a/src/views/playlist/playlist.module.css
+++ b/src/views/playlist/playlist.module.css
@@ -71,4 +71,15 @@
             width: 100%;
         }
     }
+
+    .playlist__edit {
+        background-color: var(--clr-accent);
+        border-radius: var(--border-radius);
+        color: var(--clr-dark);
+        padding: 0.5em 0.375em;
+        font-weight: 600;
+        font-size: 0.9rem;
+        display: inline-block;
+        margin-top: 2em;
+    }
 }


### PR DESCRIPTION
In this PR I covered the following: 

- styled the edit playlist button
- styled the edit playlist page form to be consistent with the design and other forms on the website
- styled the footer to have some spacing between it and the elements on the main page
- fixed the navigation bar to always display the correct active link on all pages


Results

**Playlists page**
![edit](https://github.com/user-attachments/assets/a45cc3c5-1e05-4837-9fe2-5218db336b51)

**Form**
![edit-form](https://github.com/user-attachments/assets/9f96acfe-b108-4ddc-90d8-7ec00dfef574)

**Active link styling**
![active](https://github.com/user-attachments/assets/34952bab-f5b0-4c58-ac84-71c0078914ab)